### PR TITLE
Replace alert() with non-blocking toast notifications

### DIFF
--- a/index.css
+++ b/index.css
@@ -7,6 +7,7 @@
   --text-muted-color: #888888;
   --border-color: #333333;
   --success-color: #2e7d32;
+  --error-color: #e53935;
   --font-family: "Inter", sans-serif;
 }
 
@@ -380,4 +381,44 @@ footer {
     border-right: none;
     border-bottom: 1px solid var(--border-color);
   }
+}
+
+#toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.toast {
+  background-color: var(--surface-color);
+  color: var(--text-color);
+  padding: 12px 20px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  max-width: 300px;
+  font-size: 14px;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.error {
+  background-color: rgba(229, 57, 53, 0.1);
+  border: 1px solid var(--error-color);
+  color: var(--error-color);
+}
+
+.toast.info {
+  background-color: rgba(106, 90, 205, 0.1);
+  border: 1px solid var(--primary-color);
 }

--- a/index.html
+++ b/index.html
@@ -158,6 +158,8 @@
       </section>
     </div>
 
+    <div id="toast-container"></div>
+
     <script type="module" src="index.tsx"></script>
   </body>
 </html>

--- a/index.tsx
+++ b/index.tsx
@@ -54,6 +54,9 @@ const qrCodeImg = document.getElementById("qr-code-img") as HTMLImageElement;
 const downloadQrBtn = document.getElementById(
   "download-qr-btn"
 ) as HTMLButtonElement;
+const toastContainer = document.getElementById(
+  "toast-container"
+) as HTMLDivElement;
 
 // Helper functions
 const showLoader = (message: string) => {
@@ -100,6 +103,30 @@ const parseHtmlFromResponse = (responseText: string): string => {
   return responseText;
 };
 
+const showToast = (
+  message: string,
+  type: "error" | "info" = "error",
+  duration: number = 3000
+) => {
+  const toast = document.createElement("div");
+  toast.classList.add("toast", type);
+  toast.innerText = message;
+  toastContainer.appendChild(toast);
+
+  // Trigger slide-in animation
+  setTimeout(() => {
+    toast.classList.add("show");
+  }, 100);
+
+  // Remove after duration
+  setTimeout(() => {
+    toast.classList.remove("show");
+    setTimeout(() => {
+      toast.remove();
+    }, 300); // Wait for transition to finish
+  }, duration);
+};
+
 // Main logic
 try {
   const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
@@ -131,7 +158,7 @@ try {
 
   generateBtn.addEventListener("click", async () => {
     if (!uploadedImage) {
-      alert("Please upload an image first.");
+      showToast("Please upload an image first.");
       return;
     }
 
@@ -180,7 +207,7 @@ try {
       });
     } catch (error) {
       console.error(error);
-      alert(
+      showToast(
         "Failed to generate website. Please check the console for details."
       );
     } finally {
@@ -192,11 +219,11 @@ try {
   refineBtn.addEventListener("click", async () => {
     const prompt = editPrompt.value.trim();
     if (!prompt) {
-      alert("Please enter a refinement prompt.");
+      showToast("Please enter a refinement prompt.");
       return;
     }
     if (!chat) {
-      alert("Please generate a website first.");
+      showToast("Please generate a website first.");
       return;
     }
 
@@ -214,7 +241,9 @@ try {
       editPrompt.value = ""; // Clear input
     } catch (error) {
       console.error(error);
-      alert("Failed to refine website. Please check the console for details.");
+      showToast(
+        "Failed to refine website. Please check the console for details."
+      );
     } finally {
       hideLoader();
       refineBtn.disabled = false;
@@ -231,7 +260,7 @@ try {
 
   downloadBtn.addEventListener("click", () => {
     if (!currentHtml) {
-      alert("No website to download.");
+      showToast("No website to download.");
       return;
     }
     const blob = new Blob([currentHtml], { type: "text/html;charset=utf-8" });
@@ -252,11 +281,11 @@ try {
     const token = process.env.GITHUB_TOKEN;
 
     if (!repo) {
-      alert("Please provide a name for the new repository.");
+      showToast("Please provide a name for the new repository.");
       return;
     }
     if (!currentHtml) {
-      alert("No website content to publish.");
+      showToast("No website content to publish.");
       return;
     }
     if (!token) {
@@ -411,14 +440,14 @@ try {
       URL.revokeObjectURL(url);
     } catch (error) {
       console.error("Failed to download QR code", error);
-      alert("Could not download the QR code.");
+      showToast("Could not download the QR code.");
     }
   });
 
   // File handling function
   const handleFile = async (file: File) => {
     if (!file.type.startsWith("image/")) {
-      alert("Please upload an image file.");
+      showToast("Please upload an image file.");
       return;
     }
 
@@ -430,7 +459,7 @@ try {
       generateBtn.disabled = false;
     } catch (error) {
       console.error("Error reading file:", error);
-      alert("Failed to read the image file.");
+      showToast("Failed to read the image file.");
     }
   };
 } catch (error) {


### PR DESCRIPTION
Replace alert() with Non-Blocking Toasts
Fixes #6

Issue: Blocking alert() calls disrupt UX for errors/info (e.g., missing image upload).
Fix: Added custom toast system: slides in from top-right, auto-dismisses after 3s, supports error/info types.
Changes:

HTML: Added #toast-container.
CSS: Styles for toasts (animations, variants).
TS: showToast() function; replaced all alert() with it.


Testing: Verified in Chrome/Firefox; no blocking, stacks multiple toasts, no regressions.
